### PR TITLE
Support MBC1 Cartridges

### DIFF
--- a/libgb-rs/src/memory/cartridge.rs
+++ b/libgb-rs/src/memory/cartridge.rs
@@ -12,8 +12,12 @@ const RAM_BANK_SIZE: usize = 8192;
 pub type RomBank = [u8; ROM_BANK_SIZE];
 pub type MemBank = [u8; RAM_BANK_SIZE];
 
+/// # CartridgeMapper
+/// A Trait representing A Game boy system's cartridge memory mapper. This trait is necessary
+/// to accomodate the different types of Game boy cartridges which allow for increased memory
+/// and ROM storage in several slightly different ways.
 #[automock]
-pub trait CartridgeMemoryBankController {
+pub trait CartridgeMapper {
     // TODO - think about timer, SRAM, etc. support
 
     /// Get the 8-bit number at the given address on the cartridge ROM

--- a/libgb-rs/src/memory/cartridge.rs
+++ b/libgb-rs/src/memory/cartridge.rs
@@ -6,6 +6,12 @@ mod mbc1;
 pub use basicrom::RomOnlyCartridge;
 pub use mbc1::MBC1;
 
+const ROM_BANK_SIZE: usize = 16384;
+const RAM_BANK_SIZE: usize = 8192;
+
+pub type RomBank = [u8; ROM_BANK_SIZE];
+pub type MemBank = [u8; RAM_BANK_SIZE];
+
 #[automock]
 pub trait CartridgeMemoryBankController {
     // TODO - think about timer, SRAM, etc. support

--- a/libgb-rs/src/memory/cartridge.rs
+++ b/libgb-rs/src/memory/cartridge.rs
@@ -4,7 +4,7 @@ use crate::memory::MemoryWriteError;
 mod basicrom;
 mod mbc1;
 pub use basicrom::RomOnlyCartridge;
-pub use mc1::MBC1;
+pub use mbc1::MBC1;
 
 #[automock]
 pub trait CartridgeMemoryBankController {

--- a/libgb-rs/src/memory/cartridge.rs
+++ b/libgb-rs/src/memory/cartridge.rs
@@ -2,7 +2,9 @@ use mockall::automock;
 use crate::memory::MemoryWriteError;
 
 mod basicrom;
+mod mbc1;
 pub use basicrom::RomOnlyCartridge;
+pub use mc1::MBC1;
 
 #[automock]
 pub trait CartridgeMemoryBankController {

--- a/libgb-rs/src/memory/cartridge/basicrom.rs
+++ b/libgb-rs/src/memory/cartridge/basicrom.rs
@@ -1,4 +1,4 @@
-use crate::memory::cartridge::CartridgeMemoryBankController;
+use crate::memory::cartridge::CartridgeMapper;
 use crate::memory::MemoryWriteError;
 
 const ROM_SIZE: usize = 32768;
@@ -19,7 +19,7 @@ impl RomOnlyCartridge {
     }
 }
 
-impl CartridgeMemoryBankController for RomOnlyCartridge {
+impl CartridgeMapper for RomOnlyCartridge {
     fn read_rom(&self, address: u16) -> Option<u8> {
         let address = address as usize;
         self.rom.get(address).copied()

--- a/libgb-rs/src/memory/cartridge/mbc1.rs
+++ b/libgb-rs/src/memory/cartridge/mbc1.rs
@@ -1,8 +1,9 @@
 use crate::memory::MemoryWriteError;
 
+#[derive(Debug, PartialEq, Eq)]
 enum StorageMode {
     ROM = 0,
-    RAM = 1
+    RAM = 1,
 }
 
 impl From<u8> for StorageMode {
@@ -23,9 +24,10 @@ pub type MemBank = [u8; RAM_BANK_SIZE];
 pub struct MBC1 {
     rom: Vec<RomBank>,
     ram: Vec<MemBank>,
-    storage_mode: StorageMode,
+    storage_mode: StorageMode,    
     rom_bank: u8,
     ram_bank: u8,
+    ram_enabled: bool,
     has_battery: bool
 }
 
@@ -40,39 +42,47 @@ impl MBC1 {
             rom_bank: 1,
             ram_bank: 0,
             has_battery: false,
+            ram_enabled: false
         }
     }
 
     /// Set the lower 5 bits of the rom bank value
     fn set_lower_rom_bank(&mut self, data: u8) {
-        self.rom_bank = (self.rom_bank & 0xE0) & (data & 0x1F);
+        self.rom_bank = data & 0x1F;
         // hardware bug present in MBC1 cartridges, because the 0-comparison
         // only looks at the first 5 bits
-        if self.rom_bank & 0x1F == 0 {
+        if self.rom_bank == 0 {
             self.rom_bank += 1;
         }
    }
 
-    /// Set the upper 3 bits of the rom bank value, or the ram bank value
+    /// Set the upper 2 bits of the rom bank value, or the ram bank value
     /// depending on the storage mode of the cartridge
     fn set_ram_bank(&mut self, data: u8) {
-        match self.storage_mode {
-            StorageMode::ROM => self.rom_bank = (self.rom_bank & 0x1F) & (data << 5),
-            StorageMode::RAM => self.ram_bank = data
+        self.ram_bank = data & 3;
+    }
+
+    fn get_mem_bank(&self) -> usize {
+        if self.ram.len() == 1 || self.storage_mode == StorageMode::ROM {
+            return 0;
         }
+        self.ram_bank as usize
     }
 }
 
 impl CartridgeMemoryBankController for MBC1 {
     fn read_rom(&self, address: u16) -> Option<u8> {
-        if address < ROM_BANK_SIZE as u16 {
+        let first_half = address < ROM_BANK_SIZE as u16;
+        let mut bank = self.rom_bank as usize;
+        if first_half && self.storage_mode == StorageMode::RAM && self.rom.len() > 96 {
             // ignore the first 5 bits of the bank for 0x0000->0x3FFF
             // This is the same bug as with setting the rom bank, see set_lower_rom_bank
-            return self.rom.get((self.rom_bank & 0xE0) as usize)?
-                .get(address as usize)
-                .copied()
+            bank = (self.rom_bank & 0x60) as usize;
         }
-        self.rom.get(self.rom_bank as usize)?
+        else if first_half {
+            bank = 0;
+        }
+        self.rom.get(bank)?
             .get(address as usize)
             .copied()
     }
@@ -82,6 +92,10 @@ impl CartridgeMemoryBankController for MBC1 {
         // Ignoring the "enable" call because there are no electronic components to actually
         // enable
         match address {
+            0x0 ..= 0x1FFF => {
+                self.ram_enabled = (data & 0xF) == 0xA;
+                Ok(())
+            }
             0x2000 ..= 0x3FFF => {
                 self.set_lower_rom_bank(data);
                 Ok(())
@@ -99,17 +113,118 @@ impl CartridgeMemoryBankController for MBC1 {
     }
 
     fn read_mem(&self, address: u16) -> Option<u8> {
-        self.ram.get(self.ram_bank as usize)?
-            .get(address as usize).copied()
+        if !self.ram_enabled {
+            return Some(0xFF);
+        }
+        let bank = self.get_mem_bank();
+        match self.ram.get(bank) {
+            Some(&ram_bank) => ram_bank.get(address as usize).copied(),
+            None => Some(0xFF)
+        }
     }
 
     fn write_mem(&mut self, address: u16, data: u8) -> Result<u8,MemoryWriteError> {
-        let byte = self.ram.get_mut(self.ram_bank as usize)
+        if !self.ram_enabled {
+            return Ok(0);
+        }
+        let bank = self.get_mem_bank();
+        let byte = self.ram.get_mut(bank)
             .ok_or(MemoryWriteError)?
             .get_mut(address as usize)
             .ok_or(MemoryWriteError)?;
         let original = byte.clone();
         *byte = data;
         Ok(original)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_bank(rom: Vec<[u8; ROM_BANK_SIZE]>, ram: Vec<[u8; RAM_BANK_SIZE]>) -> MBC1 {
+        MBC1 {
+            rom,
+            ram,
+            storage_mode: StorageMode::ROM,
+            rom_bank: 1,
+            ram_bank: 0,
+            has_battery: false,
+            ram_enabled: false,
+        }
+    }
+
+    #[test]
+    fn test_storage_mode_ram_access() {
+        let rom = vec!([0; ROM_BANK_SIZE]; 2);
+        let mut ram = vec!([0; RAM_BANK_SIZE]; 2);
+        ram[1][0x407] = 61;
+        let mut bank = init_bank(rom, ram);
+
+        // test that changing to RAM mode and accessing a different bank works
+        let en_ram = bank.write_rom(0x1000, 0xA);
+        assert!(en_ram.is_ok(), "check that enabling RAM succeeds");
+        let en_ram_mode = bank.write_rom(0x6000, 3);
+        assert!(en_ram_mode.is_ok(), "check that banking mode only reads first bit");
+        let change_bank = bank.write_rom(0x4000, 5);
+        assert!(change_bank.is_ok(), "check that memory bank value only uses first 2 bits");
+        let value = bank.read_mem(0x407);
+        assert_eq!(value, Some(61), "check that memory read retrieves correct value");
+        
+        let change_bank = bank.write_rom(0x4000, 0);
+        assert!(change_bank.is_ok(), "check that banking mode can be switched back to 0");
+        let bank0_value = bank.read_mem(0x0407);
+        assert_eq!(
+            bank0_value, Some(0),
+            "check that memory works correctly when banking mode is 0"
+        );
+    }
+
+    #[test]
+    fn test_ram_access_when_1_bank() {
+        let rom = vec!();
+        let ram = vec!([0; RAM_BANK_SIZE]);
+
+        let mut bank = init_bank(rom, ram);
+
+        assert!(bank.write_rom(0x1000, 0xA).is_ok());
+        assert!(bank.write_rom(0x4000, 0x2).is_ok());
+
+        let write_result = bank.write_mem(0xF0, 40);
+        assert!(write_result.is_ok());
+        
+        assert!(bank.write_rom(0x4000, 0x0).is_ok());
+        
+        let read_result = bank.read_mem(0xF0);
+        assert_eq!(
+            read_result, Some(40),
+            "Memory should only access one bank if there is only one"
+        );
+
+    }
+
+    #[test]
+    fn test_ram_access_when_not_enabled() {
+        let rom = vec!();
+        let ram = vec!();
+        let mut bank = init_bank(rom, ram);
+
+        let read_result = bank.read_mem(42);
+        let write_result = bank.write_mem(42, 28);
+        
+        assert_eq!(read_result, Some(0xFF), "Memory read should return 0xFF when RAM is disabled");
+        assert_eq!(write_result, Ok(0), "Writes should be ignored when RAM is disabled");
+    }
+
+    #[test]
+    fn test_read_bank_0() {
+        let mut rom = vec!([0; ROM_BANK_SIZE], [0; ROM_BANK_SIZE]);
+        rom[0][0x42] = 0x28;
+        let ram = vec!([0; RAM_BANK_SIZE]);
+        let bank = init_bank(rom, ram);
+
+        let result = bank.read_rom(0x42);
+
+        assert_eq!(result, Some(0x28));
     }
 }

--- a/libgb-rs/src/memory/cartridge/mbc1.rs
+++ b/libgb-rs/src/memory/cartridge/mbc1.rs
@@ -1,0 +1,101 @@
+use crate::memory::MemoryWriteError;
+
+enum StorageMode {
+    ROM = 0,
+    RAM = 1
+}
+
+impl From<u8> for StorageMode {
+    fn from(value: u8) -> Self {
+        if value % 2 == 0 { StorageMode::ROM } else { StorageMode::RAM }
+    }
+}
+
+
+use super::CartridgeMemoryBankController;
+
+const ROM_BANK_SIZE: usize = 16384;
+const RAM_BANK_SIZE: usize = 8192;
+
+pub type RomBank = [u8; ROM_BANK_SIZE];
+pub type MemBank = [u8; RAM_BANK_SIZE];
+
+pub struct MBC1 {
+    rom: Vec<RomBank>,
+    ram: Vec<MemBank>,
+    storage_mode: StorageMode,
+    rom_bank: u8,
+    ram_bank: u8,
+    has_battery: bool
+}
+
+impl MBC1 {
+
+    // TODO - figure out how I want to take in the fields and convert them into banks 
+    pub fn new() -> MBC1 {
+        MBC1 {
+            rom: vec!(),
+            ram: vec!(),
+            storage_mode: StorageMode::ROM,
+            rom_bank: 1,
+            ram_bank: 1,
+            has_battery: false,
+        }
+    }
+
+    /// Set the lower 5 bits of the rom bank value
+    fn set_lower_rom_bank(&mut self, data: u8) {
+        self.rom_bank = (self.rom_bank & 0xE0) & (data & 0x1F);
+        // hardware bug present in MBC1 cartridges
+        if self.rom_bank % 10 == 0 {
+            self.rom_bank += 1;
+        }
+   }
+
+    /// Set the upper 3 bits of the rom bank value, or the ram bank value
+    /// depending on the storage mode of the cartridge
+    fn set_ram_bank(&mut self, data: u8) {
+        match self.storage_mode {
+            StorageMode::ROM => self.rom_bank = (self.rom_bank & 0x1F) & (data << 5),
+            StorageMode::RAM => self.ram_bank = data
+        }
+    }
+}
+
+impl CartridgeMemoryBankController for MBC1 {
+    fn read_rom(&self, address: u16) -> Option<u8> {
+        todo!()
+    }
+
+    fn write_rom(&mut self, address: u16, data: u8) -> Result<(),MemoryWriteError> {
+        // TODO - does writing to the ROM change it? I'm assuming no?
+        // Ignoring the "enable" call because there are no electronic components to actually
+        // enable
+        match address {
+            0x2000 ..= 0x3FFF => {
+                self.set_lower_rom_bank(data);
+                Ok(())
+            },
+            0x4000 ..= 0x5FFF => {
+                self.set_ram_bank(data);
+                Ok(())
+            },
+            0x6000 ..= 0x7FFF => {
+                self.storage_mode = data.into();
+                Ok(())
+            }
+            _ => Err(MemoryWriteError)
+        }
+    }
+
+    fn read_mem(&self, address: u16) -> Option<u8> {
+        if address as usize > RAM_BANK_SIZE {
+            todo!()
+        }
+        todo!()
+    }
+
+    fn write_mem(&mut self, address: u16, data: u8) -> Result<u8,MemoryWriteError> {
+        todo!()
+    }
+}

--- a/libgb-rs/src/memory/cartridge/mbc1.rs
+++ b/libgb-rs/src/memory/cartridge/mbc1.rs
@@ -1,5 +1,16 @@
 use crate::memory::MemoryWriteError;
 
+/// # StorageMode
+/// An Enum representing the banking mode of an MBC1 Cartridge. 
+/// - In "ROM" Mode the the cartridge can read from up to 2 MiB of RAM (128 banks) and 8 KiB
+///   of RAM (just 1 bank). However, there is a glitch preventing access of banks 0x20, 0x40, and
+///   0x60 in this mode because of logic that locks the first half of the address space to bank 0.
+///   Changing the cartridge's RAM bank will change the upper 2 bits of the 7-bit bank number
+///
+/// - In "RAM" Mode the cartridge can read from 512 KiB of ROM and 32 KiB of RAM. In cartridges
+///   with more than 512 KiB, there can only be 8 KiB of RAM, but using this mode will allow
+///   the first half of the address space to be switched, allowing banks 0x20, 0x40, and 0x60
+///   to be accessed where bank 0 would have been.
 #[derive(Debug, PartialEq, Eq)]
 enum StorageMode {
     ROM = 0,
@@ -13,14 +24,11 @@ impl From<u8> for StorageMode {
 }
 
 
-use super::CartridgeMemoryBankController;
+use super::{CartridgeMemoryBankController, MemBank, RomBank, ROM_BANK_SIZE};
 
-const ROM_BANK_SIZE: usize = 16384;
-const RAM_BANK_SIZE: usize = 8192;
-
-pub type RomBank = [u8; ROM_BANK_SIZE];
-pub type MemBank = [u8; RAM_BANK_SIZE];
-
+/// # MBC1
+/// A struct which recreates the MBC1 (Memory Bank Controller 1) cartridge functionality
+/// for a DMG system.
 pub struct MBC1 {
     rom: Vec<RomBank>,
     ram: Vec<MemBank>,
@@ -70,27 +78,42 @@ impl MBC1 {
     }
 }
 
+// TODO - worth noting that the logic for accessing ROM might still be off, I don't know if there
+// is a reliable knowing how the hardware on an individual cartridge is wired up for using the
+// extra 2 bit register for RAM vs. ROM
 impl CartridgeMemoryBankController for MBC1 {
     fn read_rom(&self, address: u16) -> Option<u8> {
-        let first_half = address < ROM_BANK_SIZE as u16;
+        let mut address = address as usize;
         let mut bank = self.rom_bank as usize;
-        if first_half && self.storage_mode == StorageMode::RAM && self.rom.len() > 96 {
-            // ignore the first 5 bits of the bank for 0x0000->0x3FFF
-            // This is the same bug as with setting the rom bank, see set_lower_rom_bank
-            bank = (self.rom_bank & 0x60) as usize;
+        let first_half = address < ROM_BANK_SIZE;
+        let extra_storage = self.rom.len() > 32;
+
+        // The first half is mapped to 0x00, 0x20, 0x40, or 0x60 when there are enough banks
+        // and the advanced banking mode is 0
+        if first_half && self.storage_mode == StorageMode::RAM && extra_storage {
+            bank = (self.ram_bank << 5) as usize;
         }
+        // the first half is always bank 0 when the advanced banking mode is disabled
         else if first_half {
             bank = 0;
         }
+        else if extra_storage {
+            // account for the offset in the internal index
+            bank = (self.ram_bank << 5) as usize | (bank & 0x1F);
+            address -= ROM_BANK_SIZE;
+        }
+        else {
+            address -= ROM_BANK_SIZE;
+        }
+
+        // TODO - should I be handling the case where a bank is out of bounds or is returning
+        // "None" here fine?
         self.rom.get(bank)?
             .get(address as usize)
             .copied()
     }
 
     fn write_rom(&mut self, address: u16, data: u8) -> Result<(),MemoryWriteError> {
-        // TODO - does writing to the ROM change it? I'm assuming no?
-        // Ignoring the "enable" call because there are no electronic components to actually
-        // enable
         match address {
             0x0 ..= 0x1FFF => {
                 self.ram_enabled = (data & 0xF) == 0xA;
@@ -140,9 +163,11 @@ impl CartridgeMemoryBankController for MBC1 {
 
 #[cfg(test)]
 mod tests {
+    use crate::memory::cartridge::RAM_BANK_SIZE;
+
     use super::*;
 
-    fn init_bank(rom: Vec<[u8; ROM_BANK_SIZE]>, ram: Vec<[u8; RAM_BANK_SIZE]>) -> MBC1 {
+    fn init_bank(rom: Vec<RomBank>, ram: Vec<MemBank>) -> MBC1 {
         MBC1 {
             rom,
             ram,
@@ -163,17 +188,17 @@ mod tests {
 
         // test that changing to RAM mode and accessing a different bank works
         let en_ram = bank.write_rom(0x1000, 0xA);
-        assert!(en_ram.is_ok(), "check that enabling RAM succeeds");
         let en_ram_mode = bank.write_rom(0x6000, 3);
-        assert!(en_ram_mode.is_ok(), "check that banking mode only reads first bit");
-        let change_bank = bank.write_rom(0x4000, 5);
-        assert!(change_bank.is_ok(), "check that memory bank value only uses first 2 bits");
+        let first_change_bank = bank.write_rom(0x4000, 5);
         let value = bank.read_mem(0x407);
-        assert_eq!(value, Some(61), "check that memory read retrieves correct value");
-        
-        let change_bank = bank.write_rom(0x4000, 0);
-        assert!(change_bank.is_ok(), "check that banking mode can be switched back to 0");
+        let second_change_bank = bank.write_rom(0x4000, 0);
         let bank0_value = bank.read_mem(0x0407);
+
+        assert!(en_ram.is_ok(), "check that enabling RAM succeeds");
+        assert!(en_ram_mode.is_ok(), "check that banking mode only reads first bit");
+        assert!(first_change_bank.is_ok(), "check that memory bank value only uses first 2 bits");
+        assert_eq!(value, Some(61), "check that memory read retrieves correct value");
+        assert!(second_change_bank.is_ok(), "check that banking mode can be switched back to 0");
         assert_eq!(
             bank0_value, Some(0),
             "check that memory works correctly when banking mode is 0"
@@ -226,5 +251,91 @@ mod tests {
         let result = bank.read_rom(0x42);
 
         assert_eq!(result, Some(0x28));
+    }
+
+    #[test]
+    fn test_read_switching_banks() {
+        let mut rom = vec!([0; ROM_BANK_SIZE]; 4);
+        rom[1][0x28] = 0x03;
+        rom[3][0x15] = 0x62;
+        let ram = vec!([0; RAM_BANK_SIZE]);
+        let mut bank = init_bank(rom, ram);
+
+        let bank_1_result = bank.read_rom(0x4028);
+        assert!(bank.write_rom(0x2000, 0x3).is_ok(), "Change to ROM bank 3");
+        let bank_3_result = bank.read_rom(0x4015);
+
+        assert_eq!(bank_1_result, Some(0x03), "Test initial read");
+        assert_eq!(bank_3_result, Some(0x62), "Test read after switching ROM banks");
+        
+    }
+
+    #[test]
+    fn test_64_rom_banks_basic_storage_mode() {
+        let mut rom = vec!([0; ROM_BANK_SIZE]; 64);
+        rom[0][0x95] = 0x42;
+        rom[0x1][0x4] = 0x28;
+        rom[0x21][0x7] = 0x63;
+        let ram = vec!();
+        let mut bank = init_bank(rom, ram);
+
+        assert!(bank.write_rom(0x2000, 0).is_ok(), "set bank to 0");
+        let bank_0_result = bank.read_rom(0x4004);
+
+        assert!(bank.write_rom(0x2000, 1).is_ok(), "Change bank to 1");
+        let bank_1_result = bank.read_rom(0x4004);
+
+        assert!(bank.write_rom(0x4000, 0x1).is_ok(), "Set RAM bank to 1");
+        let bank_21_result = bank.read_rom(0x4007);
+        
+        let first_half_result = bank.read_rom(0x95);
+
+        assert_eq!(bank_0_result, Some(0x28), "Checking value after setting bank to 0");
+        assert_eq!(bank_1_result, Some(0x28), "Checking that bank 1 value matches bank 0");
+        assert_eq!(bank_21_result, Some(0x63), "Check that second half maps correctly in bank 21");
+        assert_eq!(first_half_result, Some(0x42), "Check that first half still maps to bank 0");
+    }
+
+    #[test]
+    fn test_64_rom_banks_advanced_storage_mode() {
+        let mut rom = vec!([0; ROM_BANK_SIZE]; 64);
+        rom[0x20][0x20] = 0x19;
+        let ram = vec!();
+        let mut bank = init_bank(rom, ram);
+
+        assert!(bank.write_rom(0x2000, 1).is_ok());
+        assert!(bank.write_rom(0x4000, 1).is_ok());
+        assert!(
+            bank.write_rom(0x6000, 1).is_ok(),
+            "Checking that storage mode is changed successfully"
+        );
+        let result = bank.read_rom(0x20);
+
+        assert_eq!(result, Some(0x19), "Check that bank 0 switches in advanced storage mode");
+    }
+
+    #[test]
+    fn test_4_rom_banks_advanced_storage_mode() {
+        let mut rom = vec!([0; ROM_BANK_SIZE]; 4);
+        rom[0][0x4] = 0x28;
+        rom[3][0x7] = 0x63;
+        let ram = vec!();
+        let mut bank = init_bank(rom, ram);
+
+        assert!(bank.write_rom(0x6000, 0x1).is_ok(), "Change into advanced banking mode");
+        assert!(bank.write_rom(0x2000, 0x3).is_ok(), "Change ROM banks");
+        assert!(
+            bank.write_rom(0x4000, 0x11).is_ok(),
+            "Change bank even though there are not enough ROM or RAM banks"
+        );
+        
+        let first_half_result = bank.read_rom(0x4);
+        let second_half_reuslt = bank.read_rom(0x4007);
+
+        assert_eq!(first_half_result, Some(0x28), "Check read result from first half of addresses");
+        assert_eq!(
+            second_half_reuslt, Some(0x63),
+            "Check read result from second half of addresses"
+        );
     }
 }

--- a/libgb-rs/src/memory/cartridge/mbc1.rs
+++ b/libgb-rs/src/memory/cartridge/mbc1.rs
@@ -24,7 +24,7 @@ impl From<u8> for StorageMode {
 }
 
 
-use super::{CartridgeMemoryBankController, MemBank, RomBank, ROM_BANK_SIZE};
+use super::{CartridgeMapper, MemBank, RomBank, ROM_BANK_SIZE};
 
 /// # MBC1
 /// A struct which recreates the MBC1 (Memory Bank Controller 1) cartridge functionality
@@ -81,7 +81,7 @@ impl MBC1 {
 // TODO - worth noting that the logic for accessing ROM might still be off, I don't know if there
 // is a reliable knowing how the hardware on an individual cartridge is wired up for using the
 // extra 2 bit register for RAM vs. ROM
-impl CartridgeMemoryBankController for MBC1 {
+impl CartridgeMapper for MBC1 {
     fn read_rom(&self, address: u16) -> Option<u8> {
         let mut address = address as usize;
         let mut bank = self.rom_bank as usize;

--- a/libgb-rs/src/memory/mod.rs
+++ b/libgb-rs/src/memory/mod.rs
@@ -1,4 +1,4 @@
-use cartridge::CartridgeMemoryBankController;
+use cartridge::CartridgeMapper;
 use mockall::automock;
 
 use crate::utils::{Merge, Split};
@@ -63,14 +63,14 @@ const DMG_RES_SIZE: usize = (DMG_RES_END - DMG_RES_START + 1) as usize;
 
 /// A Struct Storing the memory of an original Game Boy (DMG) system
 pub struct DmgMemoryController {
-    cartridge: Box<dyn CartridgeMemoryBankController>,
+    cartridge: Box<dyn CartridgeMapper>,
     ram: [u8; DMG_RAM_SIZE],
     vram: [u8; DMG_VRAM_SIZE],
     system: [u8; DMG_RES_SIZE],
 }
 
 impl DmgMemoryController {
-    pub fn new(cartridge: Box<dyn CartridgeMemoryBankController>) -> DmgMemoryController {
+    pub fn new(cartridge: Box<dyn CartridgeMapper>) -> DmgMemoryController {
         DmgMemoryController {
             cartridge,
             ram: [0; DMG_VRAM_SIZE],
@@ -156,12 +156,12 @@ impl MemoryController for DmgMemoryController {
 #[cfg(test)]
 mod tests {
     use mockall::predicate::eq;
-    use crate::memory::cartridge::MockCartridgeMemoryBankController;
+    use crate::memory::cartridge::MockCartridgeMapper;
     use super::*;
 
     #[test]
     fn test_rom_write_fails() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_write_rom()
             .return_const(Err(MemoryWriteError));
         let mut controller = DmgMemoryController::new(Box::new(mock));
@@ -176,7 +176,7 @@ mod tests {
         // NOTE - I couldn't figure out how to put in a mock Option<&u8>
         // into this without doing some jank static lifetime stuff so I'm having it
         // return None and checking that the address gets passed correctly
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_read_rom()
             .times(1)
             .with(eq(42))
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_vram_io() {
-        let mock = MockCartridgeMemoryBankController::new();
+        let mock = MockCartridgeMapper::new();
         let mut controller = DmgMemoryController::new(Box::new(mock));
 
         assert_eq!(controller.load_byte(0x8000), Some(0));
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_cart_ram_read_success() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_read_mem()
             .with(eq(42))
             .return_const(Some(0x22));
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_cart_ram_read_fail() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_read_mem()
             .with(eq(42))
             .return_const(None);
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_cart_ram_write_fail() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_write_mem()
             .with(eq(42), eq(42))
             .return_const(Err(MemoryWriteError));
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_ram_io() {
-        let mock = MockCartridgeMemoryBankController::new();
+        let mock = MockCartridgeMapper::new();
         let mut controller = DmgMemoryController::new(Box::new(mock));
 
         assert_eq!(controller.load_byte(0xC042), Some(0));
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_reserved_io() {
-        let mock = MockCartridgeMemoryBankController::new();
+        let mock = MockCartridgeMapper::new();
         let mut controller = DmgMemoryController::new(Box::new(mock));
 
         assert_eq!(controller.load_byte(0xFE42), Some(0));
@@ -268,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_load_half_word_valid_address() {
-        let mock = MockCartridgeMemoryBankController::new();
+        let mock = MockCartridgeMapper::new();
         let mut controller = DmgMemoryController::new(Box::new(mock));
         controller.store_byte(DMG_RAM_START, 0x04).unwrap();
         controller.store_byte(DMG_RAM_START + 1, 0x28).unwrap();
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_load_half_word_invalid_first_byte() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_read_mem()
             .with(eq(0x1FFF))
             .return_const(None);
@@ -293,7 +293,7 @@ mod tests {
 
     #[test]
     fn test_load_half_word_invalid_second_byte() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_read_mem()
             .with(eq(0))
             .return_const(None);
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     fn test_store_half_word_valid_address() {
-        let mock = MockCartridgeMemoryBankController::new();
+        let mock = MockCartridgeMapper::new();
         let mut controller = DmgMemoryController::new(Box::new(mock));
 
         let result = controller.store_half_word(DMG_RAM_START, 0x0428);
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn test_store_half_byte_invalid_first_byte() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_write_rom()
             .with(eq(DMG_ROM_END), eq(0x08))
             .return_const(Err(MemoryWriteError));
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_store_half_byte_invalid_second_byte() {
-        let mut mock = MockCartridgeMemoryBankController::new();
+        let mut mock = MockCartridgeMapper::new();
         mock.expect_write_mem()
             .with(eq(0), eq(0x06))
             .return_const(Err(MemoryWriteError));

--- a/libgb-rs/src/memory/mod.rs
+++ b/libgb-rs/src/memory/mod.rs
@@ -154,7 +154,7 @@ impl MemoryController for DmgMemoryController {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use mockall::predicate::eq;
     use crate::memory::cartridge::MockCartridgeMemoryBankController;
     use super::*;


### PR DESCRIPTION
The work for this is only partially completed because I realistically can't know if all of the edge cases matter until I actually test a ROM. Additionally, the lack of a constructor is because I wanted to wait until more of the MBCs are implemented, then I could come up with abstractions for constructors (and likely a good portion of the logic as well)